### PR TITLE
addressing AddTags new requirements

### DIFF
--- a/modules/addons/aws/load-balancer-controller/main.tf
+++ b/modules/addons/aws/load-balancer-controller/main.tf
@@ -20,7 +20,7 @@ provider "kubernetes" {
 }
 
 module "load_balancer_controller" {
-  source                           = "git::https://github.com/DNXLabs/terraform-aws-eks-lb-controller.git"
+  source                           = "git::https://github.com/smarunich/terraform-aws-eks-lb-controller.git"
   helm_chart_version               = var.helm_chart_version
   cluster_identity_oidc_issuer     = var.cluster_oidc_issuer_url
   cluster_identity_oidc_issuer_arn = var.oidc_provider_arn


### PR DESCRIPTION
addressing AddTags new requirements

```
  Warning  FailedDeployModel  10m  service  Failed deploy model due to AccessDenied: User: arn:aws:sts::819220072900:assumed-role/171tsed2-0-us-west-1-alb-ingress/1694619272176645550 is not authorized to perform: elasticloadbalancing:AddTags on resource: arn:aws:elasticloadbalancing:us-west-1:819220072900:targetgroup/k8s-tse-envoy-69fdc0fc91/* because no identity-based policy allows the elasticloadbalancing:AddTags action```